### PR TITLE
Feature/cice update 20260628

### DIFF
--- a/cicecore/cicedyn/analysis/ice_history.F90
+++ b/cicecore/cicedyn/analysis/ice_history.F90
@@ -479,6 +479,7 @@
       call broadcast_scalar (f_Qref, master_task)
       call broadcast_scalar (f_congel, master_task)
       call broadcast_scalar (f_frazil, master_task)
+      call broadcast_scalar (f_frazheat, master_task)
       call broadcast_scalar (f_snoice, master_task)
       call broadcast_scalar (f_dsnow, master_task)
       call broadcast_scalar (f_meltt, master_task)
@@ -547,6 +548,8 @@
       call broadcast_scalar (f_frz_onset, master_task)
       call broadcast_scalar (f_aisnap, master_task)
       call broadcast_scalar (f_hisnap, master_task)
+      call broadcast_scalar (f_ihcsnap, master_task)
+      call broadcast_scalar (f_shcsnap, master_task)
       call broadcast_scalar (f_sitimefrac, master_task)
       call broadcast_scalar (f_sithick, master_task)
       call broadcast_scalar (f_siage, master_task)
@@ -1008,6 +1011,11 @@
              "none", mps_to_cmpdy/dt, c0,                                 &
              ns1, f_frazil)
 
+         call define_hist_field(n_frazheat,"frazil_heat","W/m^2",tstr2D, tcstr, &
+             "Heat released in ocean during frazil ice production",                                       &
+             "none", c1, c0,                               &
+             ns1, f_frazheat)
+
          call define_hist_field(n_snoice,"snoice","cm/day",tstr2D, tcstr, &
              "snow-ice formation",                                        &
              "none", mps_to_cmpdy/dt, c0,                                 &
@@ -1359,6 +1367,17 @@
              "ice area snapshot",                                    &
              "none", c1, c0,                                         &
              ns1, f_aisnap)
+
+         call define_hist_field(n_ihcsnap,"ihcsnap","1",tstr2D, tcstr, &
+             "ice enthalpy snapshot",                                    &
+             "none", c1, c0,                                         &
+             ns1, f_ihcsnap)
+         
+         call define_hist_field(n_shcsnap,"shcsnap","1",tstr2D, tcstr, &
+             "snow enthalpy snapshot",                                    &
+             "none", c1, c0,                                         &
+             ns1, f_shcsnap)
+
 
          call define_hist_field(n_trsig,"trsig","N/m",tstr2D, tcstr, &
              "internal stress tensor trace",                         &
@@ -2766,6 +2785,18 @@
            call accum_hist_field(n_icepresent, iblk, worka(:,:), a2D)
          endif
 
+
+         if (f_frazheat(1:1) /= 'x') then
+           worka(:,:) = c0
+           do j = jlo, jhi
+           do i = ilo, ihi
+              worka(i,j) = - max(c0,frzmlt_init(i,j,iblk))
+           enddo
+           enddo
+           call accum_hist_field(n_frazheat, iblk, worka(:,:), a2D)
+         endif
+
+         
          ! 2D CMIP fields
 
          if (f_sitimefrac(1:1) /= 'x') then
@@ -3835,6 +3866,11 @@
                  if (n_frz_onset(ns) /= 0) a2D(i,j,n_frz_onset(ns),iblk) = spval_dbl
                  if (n_hisnap   (ns) /= 0) a2D(i,j,n_hisnap(ns),   iblk) = spval_dbl
                  if (n_aisnap   (ns) /= 0) a2D(i,j,n_aisnap(ns),   iblk) = spval_dbl
+
+        
+                 if (n_ihcsnap   (ns) /= 0) a2D(i,j,n_ihcsnap(ns),   iblk) = spval_dbl
+                 if (n_shcsnap   (ns) /= 0) a2D(i,j,n_shcsnap(ns),   iblk) = spval_dbl
+                 
                  if (n_trsig    (ns) /= 0) a2D(i,j,n_trsig(ns),    iblk) = spval_dbl
                  if (n_iage     (ns) /= 0) a2D(i,j,n_iage(ns),     iblk) = spval_dbl
                  if (n_FY       (ns) /= 0) a2D(i,j,n_FY(ns),       iblk) = spval_dbl
@@ -3880,6 +3916,23 @@
                  if (n_aisnap   (ns) /= 0) a2D(i,j,n_aisnap(ns),iblk)    = &
                        aice(i,j,iblk)
 
+                 if (n_ihcsnap(ns) /= 0) then
+                    a2D(i,j,n_ihcsnap(ns),iblk) = c0
+                    do k = 1,nzilyr
+                       a2D(i,j,n_ihcsnap(ns),iblk)=a2D(i,j,n_ihcsnap(ns),iblk)&
+                            + trcr(i,j,nt_qice+k-1,iblk) * &
+                            vice(i,j,iblk)/real(nzilyr,kind=dbl_kind)
+                    enddo
+                 endif
+                 if (n_shcsnap(ns) /= 0) then
+                    a2D(i,j,n_shcsnap(ns),iblk) = c0
+                    do k = 1,nzslyr
+                       a2D(i,j,n_shcsnap(ns),iblk)=a2D(i,j,n_shcsnap(ns),iblk)&
+                            + trcr(i,j,nt_qsno+k-1,iblk) * &
+                            vsno(i,j,iblk)/real(nzslyr,kind=dbl_kind)
+                    enddo
+                 endif
+                 
                  if (kdyn == 2) then  ! for EAP dynamics different time of output
                     if (n_trsig    (ns) /= 0) a2D(i,j,n_trsig(ns),iblk ) = &
                                         strength(i,j,iblk)

--- a/cicecore/cicedyn/analysis/ice_history.F90
+++ b/cicecore/cicedyn/analysis/ice_history.F90
@@ -3031,7 +3031,8 @@
          endif
 
          if (f_sisndmasssnf(1:1) /= 'x') then
-           call accum_hist_field(n_sisndmasssnf, iblk, fsnow(:,:,iblk), a2D)
+
+            call accum_hist_field(n_sisndmasssnf, iblk, aice_init(:,:,iblk)*fsnow(:,:,iblk), a2D)
          endif
 
          if (f_sisndmassmelt(1:1) /= 'x') then
@@ -3063,12 +3064,12 @@
          endif
 
          if (f_siflsenstop(1:1) /= 'x') then
-           worka(:,:) = c0
-           do j = jlo, jhi
-           do i = ilo, ihi
-              worka(i,j) = aice(i,j,iblk)*fsens(i,j,iblk)
-           enddo
-           enddo
+           !worka(:,:) = c0
+           !do j = jlo, jhi
+           !do i = ilo, ihi
+           !   worka(i,j) = aice(i,j,iblk)*fsens(i,j,iblk)
+           !enddo
+           !enddo
            call accum_hist_field(n_siflsenstop, iblk, aice(:,:,iblk)*fsens(:,:,iblk), a2D)
          endif
 

--- a/cicecore/cicedyn/analysis/ice_history.F90
+++ b/cicecore/cicedyn/analysis/ice_history.F90
@@ -3031,7 +3031,6 @@
          endif
 
          if (f_sisndmasssnf(1:1) /= 'x') then
-
             call accum_hist_field(n_sisndmasssnf, iblk, aice_init(:,:,iblk)*fsnow(:,:,iblk), a2D)
          endif
 

--- a/cicecore/cicedyn/analysis/ice_history_shared.F90
+++ b/cicecore/cicedyn/analysis/ice_history_shared.F90
@@ -256,6 +256,7 @@
            f_Tair      = 'm', &
            f_Tref      = 'm', f_Qref       = 'm', &
            f_congel    = 'm', f_frazil     = 'm', &
+           f_frazheat  = 'm', &
            f_snoice    = 'm', f_dsnow      = 'm', &
            f_meltt     = 'm', f_melts      = 'm', &
            f_meltb     = 'm', f_meltl      = 'm', &
@@ -292,6 +293,7 @@
            f_mlt_onset = 'm', f_frz_onset  = 'm', &
            f_iage      = 'm', f_FY         = 'm', &
            f_hisnap    = 'm', f_aisnap     = 'm', &
+           f_ihcsnap    = 'm', f_shcsnap     = 'm', &
            f_sithick   = 'x', f_sisnthick  = 'x', &
            f_siage     = 'x', f_siconc     = 'x', &
            f_sisnconc  = 'x', f_sisnmass   = 'x', &
@@ -437,6 +439,7 @@
            f_Tair,      &
            f_Tref,      f_Qref     , &
            f_congel,    f_frazil   , &
+           f_frazheat,  &
            f_snoice,    f_dsnow    , &
            f_meltt,     f_melts    , &
            f_meltb,     f_meltl    , &
@@ -473,6 +476,7 @@
            f_mlt_onset, f_frz_onset, &
            f_iage,      f_FY       , &
            f_hisnap,    f_aisnap   , &
+           f_ihcsnap,    f_shcsnap   , &
            f_sithick,   f_sisnthick, &
            f_siage,     f_siconc   , &
            f_sisnconc,  f_sisnmass , &
@@ -646,6 +650,7 @@
            n_Tair       , &
            n_Tref       , n_Qref       , &
            n_congel     , n_frazil     , &
+           n_frazheat   , &
            n_snoice     , n_dsnow      , &
            n_meltt      , n_melts      , &
            n_meltb      , n_meltl      , &
@@ -682,6 +687,7 @@
            n_dagedtt    , n_dagedtd    , &
            n_mlt_onset  , n_frz_onset  , &
            n_hisnap     , n_aisnap     , &
+           n_ihcsnap     , n_shcsnap     , &
            n_sithick    , n_sisnthick  , &
            n_siage      , n_siconc     , &
            n_sisnconc   , n_sisnmass   , &


### PR DESCRIPTION


## PR checklist
- [ ] Short (1 sentence) summary of your PR: 
Changes to history files, only:
- Added extra variables to close the cice heat budget from history files. 
   - frazheat :: Energy deficit delivered by the ocean model for frazil ice production. Not accounted for in other fluxes. 
   - ihcsnap :: instant energy deficit in sea ice 
   - shcsnap ::  instant energy deficit in sea ice
- Bugfix :: snowfall only accumulates on sea ice (history file only).

- How much do the PR code changes differ from the unmodified code? 
    - [X] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on Icepack or any other models?
    - [ ] Yes
    - [X] No
- Does this PR update the Icepack submodule?  If so, the Icepack submodule must point to a hash on Icepack's main branch.
    - [ ] Yes
    - [X] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [X] No


